### PR TITLE
Adding support for roman itals in ital sections

### DIFF
--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -521,6 +521,10 @@ h1 + *[class*="TitlepageSeriesTitleser"] {
   line-height: $gridheight * 1.5;
   font-style: italic;
   text-align: center;
+
+  em {
+    font-style: normal;
+  }
 }
 
 *[class*="TitlepageBookSubtitlestit"]:first-child, 
@@ -606,6 +610,10 @@ section[data-type="dedication"] p {
   text-align: center;
   font-style: italic;
   text-indent: 0;
+
+  em {
+    font-style: normal;
+  }
 }
 
 .texttoc {
@@ -738,6 +746,10 @@ section[data-type="preface"] *[class*="FMSubheadfmsh"], *[class*="ChapSubtitlecs
   text-align: center;
   margin-bottom: $gridheight * 1.875;
   page-break-after: avoid;
+
+  em {
+    font-style: normal;
+  }
 }
 
 section[data-type="preface"] *[class*="FMSubheadfmsh"]:first-of-type, *[class*="ChapSubtitlecst"]:first-of-type, *[class*="BMSubheadbmsh"]:first-of-type {
@@ -844,7 +856,11 @@ blockquote + *[class*="ChapOpeningText"] {
   text-align: center;
   margin-top: $gridheight * 2;
   margin-bottom: $gridheight;
-    page-break-after: avoid;
+  page-break-after: avoid;
+
+  em {
+    font-style: normal;
+  }
 }
 
 *[class*="Head-Level-2h2"] {
@@ -867,6 +883,10 @@ blockquote + *[class*="ChapOpeningText"] {
   margin-top: $gridheight * 2;
   margin-bottom: $gridheight;
   page-break-after: avoid;
+
+  em {
+    font-style: normal;
+  }
 }
 
 div[data-type="part"] {
@@ -1069,6 +1089,10 @@ p.FMEpigraphSourcefmeps {
   text-indent: -$textindent;
   margin-left: $gridheight;
   text-align: left;
+
+  em {
+    font-style: normal;
+  }
 }
 
 p[class*="ExtractSource"] {
@@ -1080,6 +1104,10 @@ p[class*="ExtractSource"] {
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic;
+
+  em {
+    font-style: normal;
+  }
 }
 
 p.LetterExtSalutationlsa {
@@ -1087,6 +1115,10 @@ p.LetterExtSalutationlsa {
   text-indent: 0;
   margin-top: $gridheight;
   margin-bottom: $gridheight;
+
+  em {
+    font-style: normal;
+  }
 }
 
 p.LetterExtAddressladd, 
@@ -1094,18 +1126,30 @@ p.LetterExtGeneralextl,
 p.LetterExtPostscriptlps {
   font-style: italic;
   text-indent: 0;
+
+  em {
+    font-style: normal;
+  }
 }
 
 p.LetterExtClosinglcl {
   font-style: italic;
   text-indent: 0;
   margin-top: $gridheight;
+
+  em {
+    font-style: normal;
+  }
 }
 
 p.LetterExtSignaturelsig {
   font-style: italic;
   text-indent: 0;
   margin-bottom: $gridheight;
+
+  em {
+    font-style: normal;
+  }
 }
 
 p[class*="ExtractSource"] em {

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+/* TO COMPILE: $ sass novella.scss pdf.css */
 /* LOCAL VARIABLES */
 /*$big2 * 1.625*/
 /* normal * o.875 */
@@ -516,6 +517,9 @@ h1 + *[class*="TitlepageSeriesTitleser"] {
   line-height: 24pt;
   font-style: italic;
   text-align: center; }
+  *[class*="TitlepageBookSubtitlestit"] em,
+  *[class*="TitlepageSeriesTitleser"] em {
+    font-style: normal; }
 
 *[class*="TitlepageBookSubtitlestit"]:first-child,
 *[class*="TitlepageSeriesTitleser"]:first-child {
@@ -545,7 +549,7 @@ section[data-type="titlepage"] *[class*="TitlepageImprintLineimp"] {
 
 section[data-type="titlepage"] *[class*="TitlepageLogologo"] {
   content: " ";
-  background-image: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerassets/torDOTcom/logo.jpg");
+  background-image: url("https://raw.githubusercontent.com/macmillanpublishers/bookmaker_assets/master/pdfmaker/images/torDOTcom/logo.jpg");
   background-position: center bottom;
   background-size: 0.58in auto;
   background-repeat: no-repeat;
@@ -590,6 +594,8 @@ section[data-type="dedication"] p {
   text-align: center;
   font-style: italic;
   text-indent: 0; }
+  section[data-type="dedication"] p em {
+    font-style: normal; }
 
 .texttoc {
   display: none; }
@@ -700,6 +706,8 @@ section[data-type="preface"] *[class*="FMSubheadfmsh"], *[class*="ChapSubtitlecs
   text-align: center;
   margin-bottom: 30pt;
   page-break-after: avoid; }
+  section[data-type="preface"] *[class*="FMSubheadfmsh"] em, *[class*="ChapSubtitlecst"] em, *[class*="BMSubheadbmsh"] em {
+    font-style: normal; }
 
 section[data-type="preface"] *[class*="FMSubheadfmsh"]:first-of-type, *[class*="ChapSubtitlecst"]:first-of-type, *[class*="BMSubheadbmsh"]:first-of-type {
   margin-top: -45pt; }
@@ -791,6 +799,8 @@ blockquote + *[class*="ChapOpeningText"] {
   margin-top: 32pt;
   margin-bottom: 16pt;
   page-break-after: avoid; }
+  *[class*="Head-Level-1h1"] em {
+    font-style: normal; }
 
 *[class*="Head-Level-2h2"] {
   text-indent: 0;
@@ -811,6 +821,8 @@ blockquote + *[class*="ChapOpeningText"] {
   margin-top: 32pt;
   margin-bottom: 16pt;
   page-break-after: avoid; }
+  *[class*="Head-Level-3h3"] em {
+    font-style: normal; }
 
 div[data-type="part"] {
   page-break-before: right;
@@ -982,6 +994,8 @@ p.FMEpigraphSourcefmeps {
   text-indent: -12pt;
   margin-left: 16pt;
   text-align: left; }
+  *[class*="Extract-VerseorPoetryextv"] em {
+    font-style: normal; }
 
 p[class*="ExtractSource"] {
   text-align: right;
@@ -991,28 +1005,40 @@ p[class*="ExtractSource"] {
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }
+  p.LetterExtBodyTextltx em, p.LetterExtBodyTextNo-Indentltx1 em {
+    font-style: normal; }
 
 p.LetterExtSalutationlsa {
   font-style: italic;
   text-indent: 0;
   margin-top: 16pt;
   margin-bottom: 16pt; }
+  p.LetterExtSalutationlsa em {
+    font-style: normal; }
 
 p.LetterExtAddressladd,
 p.LetterExtGeneralextl,
 p.LetterExtPostscriptlps {
   font-style: italic;
   text-indent: 0; }
+  p.LetterExtAddressladd em,
+  p.LetterExtGeneralextl em,
+  p.LetterExtPostscriptlps em {
+    font-style: normal; }
 
 p.LetterExtClosinglcl {
   font-style: italic;
   text-indent: 0;
   margin-top: 16pt; }
+  p.LetterExtClosinglcl em {
+    font-style: normal; }
 
 p.LetterExtSignaturelsig {
   font-style: italic;
   text-indent: 0;
   margin-bottom: 16pt; }
+  p.LetterExtSignaturelsig em {
+    font-style: normal; }
 
 p[class*="ExtractSource"] em {
   break-inside: avoid; }
@@ -1358,4 +1384,4 @@ figure.fullpage {
 img[src*="fullpage"] {
   margin-top: -1.65in; }
 
-/*# sourceMappingURL=core_tor.css.map */
+/*# sourceMappingURL=pdf.css.map */

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+/* TO COMPILE: $ sass novel.scss novel.css */
 /* LOCAL VARIABLES */
 /*$fontpath: "/Users/nellie.mckesson/Dropbox (Macmillan Publishers)/backup/automation/tor-design-samples/Imprint_PoD_template_r4 Folder/Documentfonts";*/
 @font-face {
@@ -108,9 +109,7 @@
   font-weight: normal; }
 @font-face {
   font-family: "Noto";
-  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/NotoSansSymbols-Regular.ttf");
-  font-style: normal;
-  font-weight: normal; }
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/NotoSansSymbols-Regular.ttf"); }
 @page {
   size: 5in 8in;
   margin-top: 46.5pt;
@@ -516,6 +515,9 @@ h1 + *[class*="TitlepageSeriesTitleser"] {
   line-height: 23.25pt;
   font-style: italic;
   text-align: center; }
+  *[class*="TitlepageBookSubtitlestit"] em,
+  *[class*="TitlepageSeriesTitleser"] em {
+    font-style: normal; }
 
 *[class*="TitlepageBookSubtitlestit"]:first-child,
 *[class*="TitlepageSeriesTitleser"]:first-child {
@@ -590,6 +592,8 @@ section[data-type="dedication"] p {
   text-align: center;
   font-style: italic;
   text-indent: 0; }
+  section[data-type="dedication"] p em {
+    font-style: normal; }
 
 .texttoc {
   display: none; }
@@ -700,6 +704,8 @@ section[data-type="preface"] *[class*="FMSubheadfmsh"], *[class*="ChapSubtitlecs
   text-align: center;
   margin-bottom: 29.0625pt;
   page-break-after: avoid; }
+  section[data-type="preface"] *[class*="FMSubheadfmsh"] em, *[class*="ChapSubtitlecst"] em, *[class*="BMSubheadbmsh"] em {
+    font-style: normal; }
 
 section[data-type="preface"] *[class*="FMSubheadfmsh"]:first-of-type, *[class*="ChapSubtitlecst"]:first-of-type, *[class*="BMSubheadbmsh"]:first-of-type {
   margin-top: -45pt; }
@@ -791,6 +797,8 @@ blockquote + *[class*="ChapOpeningText"] {
   margin-top: 31pt;
   margin-bottom: 15.5pt;
   page-break-after: avoid; }
+  *[class*="Head-Level-1h1"] em {
+    font-style: normal; }
 
 *[class*="Head-Level-2h2"] {
   text-indent: 0;
@@ -811,6 +819,8 @@ blockquote + *[class*="ChapOpeningText"] {
   margin-top: 31pt;
   margin-bottom: 15.5pt;
   page-break-after: avoid; }
+  *[class*="Head-Level-3h3"] em {
+    font-style: normal; }
 
 div[data-type="part"] {
   page-break-before: right;
@@ -982,6 +992,8 @@ p.FMEpigraphSourcefmeps {
   text-indent: -12pt;
   margin-left: 15.5pt;
   text-align: left; }
+  *[class*="Extract-VerseorPoetryextv"] em {
+    font-style: normal; }
 
 p[class*="ExtractSource"] {
   text-align: right;
@@ -991,28 +1003,40 @@ p[class*="ExtractSource"] {
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }
+  p.LetterExtBodyTextltx em, p.LetterExtBodyTextNo-Indentltx1 em {
+    font-style: normal; }
 
 p.LetterExtSalutationlsa {
   font-style: italic;
   text-indent: 0;
   margin-top: 15.5pt;
   margin-bottom: 15.5pt; }
+  p.LetterExtSalutationlsa em {
+    font-style: normal; }
 
 p.LetterExtAddressladd,
 p.LetterExtGeneralextl,
 p.LetterExtPostscriptlps {
   font-style: italic;
   text-indent: 0; }
+  p.LetterExtAddressladd em,
+  p.LetterExtGeneralextl em,
+  p.LetterExtPostscriptlps em {
+    font-style: normal; }
 
 p.LetterExtClosinglcl {
   font-style: italic;
   text-indent: 0;
   margin-top: 15.5pt; }
+  p.LetterExtClosinglcl em {
+    font-style: normal; }
 
 p.LetterExtSignaturelsig {
   font-style: italic;
   text-indent: 0;
   margin-bottom: 15.5pt; }
+  p.LetterExtSignaturelsig em {
+    font-style: normal; }
 
 p[class*="ExtractSource"] em {
   break-inside: avoid; }

--- a/pdfmaker/css/torDOTcom/novel.scss
+++ b/pdfmaker/css/torDOTcom/novel.scss
@@ -1,3 +1,5 @@
+/* TO COMPILE: $ sass novel.scss novel.css */
+
 /* LOCAL VARIABLES */
 $biggest: 18pt; //sizehalftitle sizepartnum
 $bigger: 16pt; //sizefst sizesubtitle sizeau sizetochead sizefmhead sizechaptitle

--- a/pdfmaker/css/torDOTcom/novella.scss
+++ b/pdfmaker/css/torDOTcom/novella.scss
@@ -1,3 +1,5 @@
+/* TO COMPILE: $ sass novella.scss pdf.css */
+
 /* LOCAL VARIABLES */
 $biggest: 18pt; //sizehalftitle sizepartnum
 $bigger: 16pt; //sizefst sizesubtitle sizeau sizetochead sizefmhead sizechaptitle

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+/* TO COMPILE: $ sass novella.scss pdf.css */
 /* LOCAL VARIABLES */
 /*$big2 * 1.625*/
 /* normal * o.875 */
@@ -110,9 +111,7 @@
   font-weight: normal; }
 @font-face {
   font-family: "Noto";
-  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/NotoSansSymbols-Regular.ttf");
-  font-style: normal;
-  font-weight: normal; }
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/NotoSansSymbols-Regular.ttf"); }
 @page {
   size: 5in 8in;
   margin-top: 52pt;
@@ -518,6 +517,9 @@ h1 + *[class*="TitlepageSeriesTitleser"] {
   line-height: 24pt;
   font-style: italic;
   text-align: center; }
+  *[class*="TitlepageBookSubtitlestit"] em,
+  *[class*="TitlepageSeriesTitleser"] em {
+    font-style: normal; }
 
 *[class*="TitlepageBookSubtitlestit"]:first-child,
 *[class*="TitlepageSeriesTitleser"]:first-child {
@@ -592,6 +594,8 @@ section[data-type="dedication"] p {
   text-align: center;
   font-style: italic;
   text-indent: 0; }
+  section[data-type="dedication"] p em {
+    font-style: normal; }
 
 .texttoc {
   display: none; }
@@ -702,6 +706,8 @@ section[data-type="preface"] *[class*="FMSubheadfmsh"], *[class*="ChapSubtitlecs
   text-align: center;
   margin-bottom: 30pt;
   page-break-after: avoid; }
+  section[data-type="preface"] *[class*="FMSubheadfmsh"] em, *[class*="ChapSubtitlecst"] em, *[class*="BMSubheadbmsh"] em {
+    font-style: normal; }
 
 section[data-type="preface"] *[class*="FMSubheadfmsh"]:first-of-type, *[class*="ChapSubtitlecst"]:first-of-type, *[class*="BMSubheadbmsh"]:first-of-type {
   margin-top: -45pt; }
@@ -793,6 +799,8 @@ blockquote + *[class*="ChapOpeningText"] {
   margin-top: 32pt;
   margin-bottom: 16pt;
   page-break-after: avoid; }
+  *[class*="Head-Level-1h1"] em {
+    font-style: normal; }
 
 *[class*="Head-Level-2h2"] {
   text-indent: 0;
@@ -813,6 +821,8 @@ blockquote + *[class*="ChapOpeningText"] {
   margin-top: 32pt;
   margin-bottom: 16pt;
   page-break-after: avoid; }
+  *[class*="Head-Level-3h3"] em {
+    font-style: normal; }
 
 div[data-type="part"] {
   page-break-before: right;
@@ -984,6 +994,8 @@ p.FMEpigraphSourcefmeps {
   text-indent: -12pt;
   margin-left: 16pt;
   text-align: left; }
+  *[class*="Extract-VerseorPoetryextv"] em {
+    font-style: normal; }
 
 p[class*="ExtractSource"] {
   text-align: right;
@@ -993,28 +1005,40 @@ p[class*="ExtractSource"] {
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }
+  p.LetterExtBodyTextltx em, p.LetterExtBodyTextNo-Indentltx1 em {
+    font-style: normal; }
 
 p.LetterExtSalutationlsa {
   font-style: italic;
   text-indent: 0;
   margin-top: 16pt;
   margin-bottom: 16pt; }
+  p.LetterExtSalutationlsa em {
+    font-style: normal; }
 
 p.LetterExtAddressladd,
 p.LetterExtGeneralextl,
 p.LetterExtPostscriptlps {
   font-style: italic;
   text-indent: 0; }
+  p.LetterExtAddressladd em,
+  p.LetterExtGeneralextl em,
+  p.LetterExtPostscriptlps em {
+    font-style: normal; }
 
 p.LetterExtClosinglcl {
   font-style: italic;
   text-indent: 0;
   margin-top: 16pt; }
+  p.LetterExtClosinglcl em {
+    font-style: normal; }
 
 p.LetterExtSignaturelsig {
   font-style: italic;
   text-indent: 0;
   margin-bottom: 16pt; }
+  p.LetterExtSignaturelsig em {
+    font-style: normal; }
 
 p[class*="ExtractSource"] em {
   break-inside: avoid; }


### PR DESCRIPTION
Adds definitions for reverse italics within sections that are italic by default. To achieve this, the reverse-italic text should be tagged as span italic chars.

@mattretzer @ericawarren Matt or Erica, can you review and merge if it looks ok?