### PR TITLE
Handwriting font support, 2 new spans + extract-note in pdf css

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ To add a new global style:
 1. Add your new style either in the same location as the existing rules for that element, or in a new line in the file if no other rules exist.
 1. If any of your new rules include measurements or sizes, be sure to base them on the variables, rather than hardcoding them. If no appropriate variable exists, you may add one. However, note that you'll need to add it to both torDOTcom/novella.scss and torDOTcom/novel.scss.
 1. Generate the new CSS files. You'll need to generate 3 files:
-  * bookmaker_assets$ cd pdfmaker
-  * pdfmaker$ cd torDOTcom
+  * bookmaker_assets$ cd pdfmaker/css/torDOTcom
   * torDOTcom$ sass novella.scss pdf.css
   * torDOTcom$ sass novel.scss novel.css
   * torDOTcom$ sass novella.scss core_tor.css

--- a/epubmaker/css/generic/epub.css
+++ b/epubmaker/css/generic/epub.css
@@ -194,12 +194,16 @@ text-decoration: none;
 
 *[class^="spanitaliccharacters"],
 *[class^="spansmcapital"],
-*[class^="spansmcapboldital"] {
+*[class^="spansmcapboldital"],
+*[class^="spanaltfont1span1"],
+*[class^="spanaltfont2span2"] {
   font-style: italic;
   }
 .spanitaliccharactersital,
 .spansmcapitalscital,
-.spansmcapbolditalscbi {
+.spansmcapbolditalscbi,
+.spanaltfont1span1,
+.spanaltfont2span2 {
   font-style: italic;
   }
 *[class^="spanboldfacecharacters"],

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1111,6 +1111,13 @@ p[class*="ExtractSource"] {
   orphans: 2;
 }
 
+p[class*="Extract-Noteextn"] {
+	text-indent: none;
+	text-align: center;
+	margin: $gridheight 16pt;
+	hyphens: none;
+}
+
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic;
 

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1114,20 +1114,17 @@ p[class*="ExtractSource"] {
 p[class*="Extract-Noteextn"] {
 	text-indent: none;
 	text-align: center;
-	margin: $gridheight;
 	hyphens: none;
 }
 
 span.spanaltfont1span1 {
   	font-family: FeltpenCom-Medium;
   	font-size: $sizehwritingprint;
-  	line-height: $gridheight;
   	letter-spacing: .02em; }
 
 span.spanaltfont2span2 {
   	font-family: BerrangerHandITCStd;
-  	font-size: $sizehwritingnormal;
-  	line-height: $gridheight; }
+  	font-size: $sizehwritingnormal; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic;

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1114,9 +1114,20 @@ p[class*="ExtractSource"] {
 p[class*="Extract-Noteextn"] {
 	text-indent: none;
 	text-align: center;
-	margin: $gridheight 16pt;
+	margin: $gridheight;
 	hyphens: none;
 }
+
+span.spanaltfont1span1 {
+  	font-family: FeltpenCom-Medium;
+  	font-size: $sizehwritingprint;
+  	line-height: $gridheight;
+  	letter-spacing: .02em; }
+
+span.spanaltfont2span2 {
+  	font-family: BerrangerHandITCStd;
+  	font-size: $sizehwritingnormal;
+  	line-height: $gridheight; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic;

--- a/pdfmaker/css/_modules/font_berrangerhanditc.scss
+++ b/pdfmaker/css/_modules/font_berrangerhanditc.scss
@@ -1,0 +1,6 @@
+@font-face {
+  font-family: "BerrangerHandITCStd";
+  src: url('#{$fontpath}/BerrangerHandITCStd.otf');
+  font-style: normal;
+  font-weight: normal;
+}

--- a/pdfmaker/css/_modules/font_feltpencom.scss
+++ b/pdfmaker/css/_modules/font_feltpencom.scss
@@ -1,0 +1,6 @@
+@font-face {
+font-family: "FeltpenCom-Medium";
+src: url('#{$fontpath}/FeltpenCom-Medium.ttf');
+font-style: normal;
+font-weight: normal;
+}

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -112,6 +112,16 @@
 @font-face {
   font-family: "Noto";
   src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/NotoSansSymbols-Regular.ttf"); }
+@font-face {
+  font-family: "BerrangerHandITCStd";
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/BerrangerHandITCStd.otf");
+  font-style: normal;
+  font-weight: normal; }
+@font-face {
+  font-family: "FeltpenCom-Medium";
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/FeltpenCom-Medium.ttf");
+  font-style: normal;
+  font-weight: normal; }
 @page {
   size: 5in 8in;
   margin-top: 52pt;
@@ -1009,6 +1019,23 @@ p[class*="ExtractSource"] {
   font-weight: 600;
   widows: 2;
   orphans: 2; }
+
+p[class*="Extract-Noteextn"] {
+  text-indent: none;
+  text-align: center;
+  margin: 16pt;
+  hyphens: none; }
+
+span.spanaltfont1span1 {
+  font-family: FeltpenCom-Medium;
+  font-size: 12.8pt;
+  line-height: 16pt;
+  letter-spacing: .02em; }
+
+span.spanaltfont2span2 {
+  font-family: BerrangerHandITCStd;
+  font-size: 11.04pt;
+  line-height: 16pt; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1023,19 +1023,16 @@ p[class*="ExtractSource"] {
 p[class*="Extract-Noteextn"] {
   text-indent: none;
   text-align: center;
-  margin: 16pt;
   hyphens: none; }
 
 span.spanaltfont1span1 {
   font-family: FeltpenCom-Medium;
-  font-size: 12.8pt;
-  line-height: 16pt;
+  font-size: 12.75pt;
   letter-spacing: .02em; }
 
 span.spanaltfont2span2 {
   font-family: BerrangerHandITCStd;
-  font-size: 11.04pt;
-  line-height: 16pt; }
+  font-size: 11pt; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1021,19 +1021,16 @@ p[class*="ExtractSource"] {
 p[class*="Extract-Noteextn"] {
   text-indent: none;
   text-align: center;
-  margin: 15.5pt;
   hyphens: none; }
 
 span.spanaltfont1span1 {
   font-family: FeltpenCom-Medium;
-  font-size: 12.4pt;
-  line-height: 15.5pt;
+  font-size: 12.5pt;
   letter-spacing: .02em; }
 
 span.spanaltfont2span2 {
   font-family: BerrangerHandITCStd;
-  font-size: 10.695pt;
-  line-height: 15.5pt; }
+  font-size: 10.75pt; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -110,6 +110,16 @@
 @font-face {
   font-family: "Noto";
   src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/NotoSansSymbols-Regular.ttf"); }
+@font-face {
+  font-family: "BerrangerHandITCStd";
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/BerrangerHandITCStd.otf");
+  font-style: normal;
+  font-weight: normal; }
+@font-face {
+  font-family: "FeltpenCom-Medium";
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/FeltpenCom-Medium.ttf");
+  font-style: normal;
+  font-weight: normal; }
 @page {
   size: 5in 8in;
   margin-top: 46.5pt;
@@ -1007,6 +1017,23 @@ p[class*="ExtractSource"] {
   font-weight: 600;
   widows: 2;
   orphans: 2; }
+
+p[class*="Extract-Noteextn"] {
+  text-indent: none;
+  text-align: center;
+  margin: 15.5pt;
+  hyphens: none; }
+
+span.spanaltfont1span1 {
+  font-family: FeltpenCom-Medium;
+  font-size: 12.4pt;
+  line-height: 15.5pt;
+  letter-spacing: .02em; }
+
+span.spanaltfont2span2 {
+  font-family: BerrangerHandITCStd;
+  font-size: 10.695pt;
+  line-height: 15.5pt; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }

--- a/pdfmaker/css/torDOTcom/novel.scss
+++ b/pdfmaker/css/torDOTcom/novel.scss
@@ -47,6 +47,7 @@ $sizecode: $smaller;
 $sizepoetry: 10.5pt;
 $sizeextract: 10.5pt;
 $sizeextracthead: $normal;
+
 $sizedateline: $small;
 $sizeepigraph: $small;
 $sizerunfoot: 9pt;
@@ -56,6 +57,8 @@ $sizefootnote: 9pt;
 $sizecaption: $smaller;
 $sizefigsrc: 7pt;
 $sizesuperscript: 6pt;
+$sizehwritingprint: $gridheight * .8;
+$sizehwritingnormal: $gridheight * .69;
 
 $hanging: -5pt;
 
@@ -144,17 +147,5 @@ figure.fullpage {
   margin-inside: -0.81in;
   margin-outside: -0.69in; }
 
-img[src*="fullpage"] {;
+img[src*="fullpage"] {
   margin-top: -1.4in; }
-
-span.spanaltfont1span1 {
-  	font-family: FeltpenCom-Medium;
-  	font-size: 12.5pt;
-  	line-height: $gridheight;
-  	letter-spacing: .02em; }
-
-span.spanaltfont2span2 {
-  	font-family: BerrangerHandITCStd;
-  	font-size: 10.75pt;
-  	line-height: $gridheight;
-  	letter-spacing: 0; }

--- a/pdfmaker/css/torDOTcom/novel.scss
+++ b/pdfmaker/css/torDOTcom/novel.scss
@@ -57,8 +57,8 @@ $sizefootnote: 9pt;
 $sizecaption: $smaller;
 $sizefigsrc: 7pt;
 $sizesuperscript: 6pt;
-$sizehwritingprint: $gridheight * .8;
-$sizehwritingnormal: $gridheight * .69;
+$sizehwritingprint: 12.5pt;
+$sizehwritingnormal: 10.75pt;
 
 $hanging: -5pt;
 

--- a/pdfmaker/css/torDOTcom/novel.scss
+++ b/pdfmaker/css/torDOTcom/novel.scss
@@ -23,7 +23,7 @@ $insidemargin: 50pt;
 $textindent: 12pt;
 
 $sizetitle: 25pt;
-$sizesubtitle: $bigger; 
+$sizesubtitle: $bigger;
 $sizeau: $bigger;
 $sizetitlepagetext: $small;
 $sizefst: $bigger;
@@ -68,7 +68,7 @@ $htmargintop: ($gridheight * 4);
 
 $ctmargintop: 0pt;
 $ctmarginbottom: 5pt;
-$comargintop: ($gridheight * 4); 
+$comargintop: ($gridheight * 4);
 $cemargintop: ($gridheight * 2);
 $cemarginbottom: ($gridheight * 3);
 $prmargintop: ($gridheight * 2);
@@ -89,6 +89,8 @@ $fontpath: "http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfont
 @import "../_modules/font_sourcecodepro.scss";
 @import "../_modules/font_timesnewroman.scss";
 @import "../_modules/font_noto.scss";
+@import "../_modules/font_berrangerhanditc.scss";
+@import "../_modules/font_feltpencom.scss";
 
 @import "../_modules/base.scss";
 
@@ -119,20 +121,20 @@ $fontpath: "http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfont
   margin-bottom: 31pt;
 }
 
-div.runheadleft { 
+div.runheadleft {
   font-variant: prince-opentype(onum);
 }
 
-div.runheadright { 
+div.runheadright {
   font-variant: prince-opentype(onum);
 }
 
-div.runheadleft::before { 
+div.runheadleft::before {
   content: counter(page)" • ";
   font-style: normal;
 }
 
-div.runheadright::after { 
+div.runheadright::after {
   content: " • "counter(page);
   font-style: normal;
 }
@@ -144,3 +146,15 @@ figure.fullpage {
 
 img[src*="fullpage"] {;
   margin-top: -1.4in; }
+
+span.spanaltfont1span1 {
+  	font-family: FeltpenCom-Medium;
+  	font-size: 12.5pt;
+  	line-height: $gridheight;
+  	letter-spacing: .02em; }
+
+span.spanaltfont2span2 {
+  	font-family: BerrangerHandITCStd;
+  	font-size: 10.75pt;
+  	line-height: $gridheight;
+  	letter-spacing: 0; }

--- a/pdfmaker/css/torDOTcom/novella.scss
+++ b/pdfmaker/css/torDOTcom/novella.scss
@@ -68,7 +68,7 @@ $htmargintop: ($gridheight * 1);
 
 $ctmargintop: 11pt;
 $ctmarginbottom: 61pt;
-$comargintop: ($gridheight * 4); 
+$comargintop: ($gridheight * 4);
 $cemargintop: ($gridheight * 2);
 $cemarginbottom: ($gridheight * 3);
 $prmargintop: 16pt;
@@ -89,6 +89,8 @@ $fontpath: "http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfont
 @import "../_modules/font_sourcecodepro.scss";
 @import "../_modules/font_timesnewroman.scss";
 @import "../_modules/font_noto.scss";
+@import "../_modules/font_berrangerhanditc.scss";
+@import "../_modules/font_feltpencom.scss";
 
 @import "../_modules/base.scss";
 
@@ -119,3 +121,15 @@ figure.fullpage {
 
 img[src*="fullpage"] {;
   margin-top: -1.65in; }
+
+span.spanaltfont1span1 {
+	font-family: FeltpenCom-Medium;
+	font-size: 12.75pt;
+	line-height: $gridheight;
+	letter-spacing: .02em; }
+
+span.spanaltfont2span2 {
+	font-family: BerrangerHandITCStd;
+	font-size: 11pt;
+	line-height: $gridheight;
+	letter-spacing: 0; }

--- a/pdfmaker/css/torDOTcom/novella.scss
+++ b/pdfmaker/css/torDOTcom/novella.scss
@@ -121,5 +121,5 @@ figure.fullpage {
   margin-inside: -1in;
   margin-outside: -0.75in; }
 
-img[src*="fullpage"] {;
+img[src*="fullpage"] {
   margin-top: -1.65in; }

--- a/pdfmaker/css/torDOTcom/novella.scss
+++ b/pdfmaker/css/torDOTcom/novella.scss
@@ -56,6 +56,8 @@ $sizefootnote: 9pt;
 $sizecaption: $smaller;
 $sizefigsrc: 7pt;
 $sizesuperscript: 6pt;
+$sizehwritingprint: $gridheight * .8;
+$sizehwritingnormal: $gridheight * .69;
 
 $hanging: -5pt;
 
@@ -121,15 +123,3 @@ figure.fullpage {
 
 img[src*="fullpage"] {;
   margin-top: -1.65in; }
-
-span.spanaltfont1span1 {
-	font-family: FeltpenCom-Medium;
-	font-size: 12.75pt;
-	line-height: $gridheight;
-	letter-spacing: .02em; }
-
-span.spanaltfont2span2 {
-	font-family: BerrangerHandITCStd;
-	font-size: 11pt;
-	line-height: $gridheight;
-	letter-spacing: 0; }

--- a/pdfmaker/css/torDOTcom/novella.scss
+++ b/pdfmaker/css/torDOTcom/novella.scss
@@ -56,8 +56,8 @@ $sizefootnote: 9pt;
 $sizecaption: $smaller;
 $sizefigsrc: 7pt;
 $sizesuperscript: 6pt;
-$sizehwritingprint: $gridheight * .8;
-$sizehwritingnormal: $gridheight * .69;
+$sizehwritingprint: 12.75pt;
+$sizehwritingnormal: 11pt;
 
 $hanging: -5pt;
 

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -112,6 +112,16 @@
 @font-face {
   font-family: "Noto";
   src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/NotoSansSymbols-Regular.ttf"); }
+@font-face {
+  font-family: "BerrangerHandITCStd";
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/BerrangerHandITCStd.otf");
+  font-style: normal;
+  font-weight: normal; }
+@font-face {
+  font-family: "FeltpenCom-Medium";
+  src: url("http://www.macmillan.tools.vhost.zerolag.com/bookmaker/bookmakerfonts/FeltpenCom-Medium.ttf");
+  font-style: normal;
+  font-weight: normal; }
 @page {
   size: 5in 8in;
   margin-top: 52pt;
@@ -1009,6 +1019,23 @@ p[class*="ExtractSource"] {
   font-weight: 600;
   widows: 2;
   orphans: 2; }
+
+p[class*="Extract-Noteextn"] {
+  text-indent: none;
+  text-align: center;
+  margin: 16pt;
+  hyphens: none; }
+
+span.spanaltfont1span1 {
+  font-family: FeltpenCom-Medium;
+  font-size: 12.8pt;
+  line-height: 16pt;
+  letter-spacing: .02em; }
+
+span.spanaltfont2span2 {
+  font-family: BerrangerHandITCStd;
+  font-size: 11.04pt;
+  line-height: 16pt; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1023,19 +1023,16 @@ p[class*="ExtractSource"] {
 p[class*="Extract-Noteextn"] {
   text-indent: none;
   text-align: center;
-  margin: 16pt;
   hyphens: none; }
 
 span.spanaltfont1span1 {
   font-family: FeltpenCom-Medium;
-  font-size: 12.8pt;
-  line-height: 16pt;
+  font-size: 12.75pt;
   letter-spacing: .02em; }
 
 span.spanaltfont2span2 {
   font-family: BerrangerHandITCStd;
-  font-size: 11.04pt;
-  line-height: 16pt; }
+  font-size: 11pt; }
 
 p.LetterExtBodyTextltx, p.LetterExtBodyTextNo-Indentltx1 {
   font-style: italic; }


### PR DESCRIPTION
For issue: https://github.com/macmillanpublishers/bookmaker_assets/issues/41
One discrepancy re: Jamie's request: he wanted 16pt L & R margins for extract note style; but for simplicity I set it to match gridheight (which is 16pt for novel but 15.5 for novella).  
This matches the blockquote margins, so I think it make sense that the margins be proportional & calculated.  
I also made font sizes for both spans calculated based on gridheight, using a factor that gives a product between the novel and novella figures specified by Jaime. 