### PR TITLE
Adding support for custom space break images

### DIFF
--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1415,6 +1415,11 @@ p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadle
   margin-top: 0pt;
 }
 
+.customimage {
+  background-image: none;
+  height: auto;
+}
+
 p.PageBreakpb {
   display: none;
 }

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1415,7 +1415,7 @@ p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadle
   margin-top: 0pt;
 }
 
-.customimage {
+p.customimage {
   background-image: none;
   height: auto;
 }

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1273,6 +1273,16 @@ figure.customimage {
   float: none;
 }
 
+figure.customimage {
+  padding: ($gridheight * 0.5) 0;
+  margin-top: $gridheight;
+  margin-bottom: ($gridheight * 0.625);
+  float: none; }
+
+figure.customimage img {
+  padding: 0;
+  margin: 0; }
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1269,11 +1269,6 @@ figure {
 }
 
 figure.customimage {
-  margin-bottom: $gridheight;
-  float: none;
-}
-
-figure.customimage {
   padding: ($gridheight * 0.5) 0;
   margin-top: $gridheight;
   margin-bottom: ($gridheight * 0.625);

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1268,6 +1268,11 @@ figure {
   float: top unless-fit;
 }
 
+figure.customimage {
+  margin-bottom: $gridheight;
+  float: none;
+}
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1147,6 +1147,10 @@ figure {
   text-align: center;
   float: top unless-fit; }
 
+figure.customimage {
+  margin-bottom: 16pt;
+  float: none; }
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1276,7 +1276,7 @@ p.SpaceBreakwithOrnamentorn + div.runfoot + div.runheadright + div.runheadleft +
 p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadleft + blockquote {
   margin-top: 0pt; }
 
-.customimage {
+p.customimage {
   background-image: none;
   height: auto; }
 

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1151,6 +1151,16 @@ figure.customimage {
   margin-bottom: 16pt;
   float: none; }
 
+figure.customimage {
+  padding: 8pt 0;
+  margin-top: 16pt;
+  margin-bottom: 10pt;
+  float: none; }
+
+figure.customimage img {
+  padding: 0;
+  margin: 0; }
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1148,10 +1148,6 @@ figure {
   float: top unless-fit; }
 
 figure.customimage {
-  margin-bottom: 16pt;
-  float: none; }
-
-figure.customimage {
   padding: 8pt 0;
   margin-top: 16pt;
   margin-bottom: 10pt;

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1276,6 +1276,10 @@ p.SpaceBreakwithOrnamentorn + div.runfoot + div.runheadright + div.runheadleft +
 p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadleft + blockquote {
   margin-top: 0pt; }
 
+.customimage {
+  background-image: none;
+  height: auto; }
+
 p.PageBreakpb {
   display: none; }
 

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1145,6 +1145,10 @@ figure {
   text-align: center;
   float: top unless-fit; }
 
+figure.customimage {
+  margin-bottom: 15.5pt;
+  float: none; }
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1146,10 +1146,6 @@ figure {
   float: top unless-fit; }
 
 figure.customimage {
-  margin-bottom: 15.5pt;
-  float: none; }
-
-figure.customimage {
   padding: 7.75pt 0;
   margin-top: 15.5pt;
   margin-bottom: 9.6875pt;

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1274,6 +1274,10 @@ p.SpaceBreakwithOrnamentorn + div.runfoot + div.runheadright + div.runheadleft +
 p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadleft + blockquote {
   margin-top: 0pt; }
 
+.customimage {
+  background-image: none;
+  height: auto; }
+
 p.PageBreakpb {
   display: none; }
 

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1149,6 +1149,16 @@ figure.customimage {
   margin-bottom: 15.5pt;
   float: none; }
 
+figure.customimage {
+  padding: 7.75pt 0;
+  margin-top: 15.5pt;
+  margin-bottom: 9.6875pt;
+  float: none; }
+
+figure.customimage img {
+  padding: 0;
+  margin: 0; }
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1274,7 +1274,7 @@ p.SpaceBreakwithOrnamentorn + div.runfoot + div.runheadright + div.runheadleft +
 p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadleft + blockquote {
   margin-top: 0pt; }
 
-.customimage {
+p.customimage {
   background-image: none;
   height: auto; }
 

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1147,6 +1147,10 @@ figure {
   text-align: center;
   float: top unless-fit; }
 
+figure.customimage {
+  margin-bottom: 16pt;
+  float: none; }
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1409,7 +1409,11 @@ p.BookmakerPageBreakbr,
 *[class*="loosen"], .bookmakerloosenbkl {
   letter-spacing: 0.2pt; }
 
-/*@import "../_modules/gridlines.scss";*/
+@page {
+  background-image: url("https://raw.githubusercontent.com/macmillanpublishers/bookmaker_assets/master/pdfmaker/images/grid.jpg");
+  background-position: top left;
+  background-size: auto 16pt;
+  background-repeat: repeat-y; }
 @page part {
   @top-center {
     vertical-align: bottom; } }

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1276,7 +1276,7 @@ p.SpaceBreakwithOrnamentorn + div.runfoot + div.runheadright + div.runheadleft +
 p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadleft + blockquote {
   margin-top: 0pt; }
 
-.customimage {
+p.customimage {
   background-image: none;
   height: auto; }
 

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1151,6 +1151,16 @@ figure.customimage {
   margin-bottom: 16pt;
   float: none; }
 
+figure.customimage {
+  padding: 8pt 0;
+  margin-top: 16pt;
+  margin-bottom: 10pt;
+  float: none; }
+
+figure.customimage img {
+  padding: 0;
+  margin: 0; }
+
 figure.fullpage {
   float: top unless-fit;
   box-sizing: border-box;
@@ -1409,11 +1419,7 @@ p.BookmakerPageBreakbr,
 *[class*="loosen"], .bookmakerloosenbkl {
   letter-spacing: 0.2pt; }
 
-@page {
-  background-image: url("https://raw.githubusercontent.com/macmillanpublishers/bookmaker_assets/master/pdfmaker/images/grid.jpg");
-  background-position: top left;
-  background-size: auto 16pt;
-  background-repeat: repeat-y; }
+/*@import "../_modules/gridlines.scss";*/
 @page part {
   @top-center {
     vertical-align: bottom; } }

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1148,10 +1148,6 @@ figure {
   float: top unless-fit; }
 
 figure.customimage {
-  margin-bottom: 16pt;
-  float: none; }
-
-figure.customimage {
   padding: 8pt 0;
   margin-top: 16pt;
   margin-bottom: 10pt;

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1276,6 +1276,10 @@ p.SpaceBreakwithOrnamentorn + div.runfoot + div.runheadright + div.runheadleft +
 p.SpaceBreakwithALTOrnamentorn2 + div.runfoot + div.runheadright + div.runheadleft + blockquote {
   margin-top: 0pt; }
 
+.customimage {
+  background-image: none;
+  height: auto; }
+
 p.PageBreakpb {
   display: none; }
 


### PR DESCRIPTION
Adds CSS handling for new custom space break images, added by users via processing instructions and transformed in https://github.com/macmillanpublishers/bookmaker/blob/master/core/htmlmaker/evaluate_pis.js and https://github.com/macmillanpublishers/bookmaker_addons/blob/master/epubmaker_postprocessing.rb

@mattretzer Matt can you review and approve?