### PR TITLE
suppressing header elements in pdf css

### DIFF
--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -1697,3 +1697,7 @@ p.BookmakerPageBreakbr,
   text-align: right;
   text-indent: 0;
 }
+
+header {
+  display: none;
+}

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -1611,6 +1611,9 @@ p.BookmakerPageBreakbr,
   text-align: right;
   text-indent: 0; }
 
+header {
+  display: none; }
+
 /*@import "../_modules/gridlines.scss";*/
 @page part {
   @top-center {

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -1609,6 +1609,9 @@ p.BookmakerPageBreakbr,
   text-align: right;
   text-indent: 0; }
 
+header {
+  display: none; }
+
 /*@import "../_modules/gridlines.scss";*/
 @page part {
   @top-center {}

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -1611,6 +1611,9 @@ p.BookmakerPageBreakbr,
   text-align: right;
   text-indent: 0; }
 
+header {
+  display: none; }
+
 /*@import "../_modules/gridlines.scss";*/
 @page part {
   @top-center {


### PR DESCRIPTION
@nelliemckesson , please review! 
(re: https://github.com/macmillanpublishers/bookmaker_assets/issues/52)

We could go ahead and merge this into master instead..  The only other edit on the sectionstartstaging branch for this repo is handling for PageBreaks, which should have no effect since .PageBreakpb's are already stripped in the xsl, right?