### PR TITLE
Eu csspatch

### DIFF
--- a/epubmaker/css/generic/epub.css
+++ b/epubmaker/css/generic/epub.css
@@ -1717,17 +1717,17 @@ ol li,
   margin-top: 0.5em;
   }
 
-li[class*"ListNum"]
+li[class^="ListNum"]
 {
   list-style-type: decimal;
 }
-li[class*"ListUnnum"]
+li[class^="ListUnnum"]
 {
   list-style-type: none;
 }
-li[class*="ListAlpha"]
-{ 
-  list-style-type: lower-alpha; 
+li[class^="ListAlpha"]
+{
+  list-style-type: lower-alpha;
 }
 
 .NumberedParagraphsnp {

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -830,7 +830,8 @@ h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: $gridheight * 5;
 }
 
-/* remove top margins from Dedication and Copyright inserted CTNP */
+/* remove top margins from Dedication, FM Epigraph, and Copyright inserted CTNP */
+section[data-type="preface"].epigraph h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 0; }
@@ -1097,13 +1098,8 @@ section[data-type="preface"].epigraph,
   margin-top: $gridheight * 2;
 }
 
-p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
-p[class*="EpigraphSource"] + p[class*="Epigraph-verse"] {
-  margin-top: $gridheight * 2;
-}
-
 section[data-type="dedication"] blockquote[data-type="epigraph"],
-section[data-type="preface"].epigraph {
+section[data-type="preface"].epigraph blockquote[data-type="epigraph"] {
   margin-left: 0;
   margin-right: 0;
 }
@@ -1118,14 +1114,16 @@ section[data-type="preface"] p[class*="Epigraph-non-verse"] {
   text-align: left;
   margin-left: $gridheight * 3.25;
   margin-right: $normal * 3;
-  text-indent: $textindent;
+  text-indent: -$textindent;
 }
 
-section[data-type="preface"] p[class*="Epigraph-non-verse"]:first-of-type,
-section[data-type="dedication"] p[class*="Epigraph-non-verse"]:first-of-type {
+section[data-type="dedication"] p[class*="Epigraph-non-verse"],
+section[data-type="preface"].epigraph p[class*="Epigraph-non-verse"]  { /*edit 7*/
+  margin-left: 36pt;
   text-indent: 0; }
 
-section[data-type="dedication"] p[class*="EpigraphSource"] {
+section[data-type="dedication"] p[class*="EpigraphSource"],
+section[data-type="preface"] p[class*="EpigraphSource"]  {
   font-family: "ArnoPro-SmText", serif, "Noto";
   font-weight: 600;
   font-size: $sizeepigraph;
@@ -1175,7 +1173,7 @@ section[data-type="introduction"] > blockquote[data-type="epigraph"] p {
   font-family: "ArnoPro-SmText", "Noto";
   font-size: $sizeepigraph;
   line-height: $gridheight;
-  text-align: left;
+  /* text-align: left;  <-- messing with FM epigraph source alignment*/
 }
 
 p.ChapEpigraph-versecepiv,

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -298,7 +298,7 @@
   @top-center {
     content: normal; }
   @bottom-center {
-    content: normal; } 
+    content: normal; }
 }
 
 body {
@@ -804,6 +804,7 @@ section[data-type="titlepage"] + section[data-type="chapter"],
 section[data-type="halftitlepage"] + section[data-type="chapter"],
 section[data-type="copyright-page"] + section[data-type="chapter"],
 section[data-type="dedication"] + section[data-type="chapter"],
+section[data-type="acknowledgments"] + section[data-type="chapter"],
 nav[data-type="toc"] + section[data-type="chapter"],
 div[data-type="part"] + section[data-type="chapter"] {
   page-break-before: right;
@@ -1087,11 +1088,11 @@ section[data-type="dedication"] p:first-child {
 section[data-type="dedication"] blockquote[data-type="epigraph"],
 section[data-type="preface"].epigraph,
 .Dedicationded + p[class*="Epigraph"] {
-  page-break-before: always;
+  page-break-before: right;
   margin-top: $gridheight * 2;
 }
 
-p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"], 
+p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
 p[class*="EpigraphSource"] + p[class*="Epigraph-verse"] {
   margin-top: $gridheight * 2;
 }
@@ -1116,7 +1117,7 @@ section[data-type="preface"] p[class*="Epigraph-non-verse"] {
 }
 
 section[data-type="preface"] p[class*="Epigraph-non-verse"]:first-of-type,
-section[data-type="dedication"] p[class*="Epigraph-non-verse"]:first-of-type {  
+section[data-type="dedication"] p[class*="Epigraph-non-verse"]:first-of-type {
   text-indent: 0; }
 
 section[data-type="dedication"] p[class*="EpigraphSource"] {
@@ -1491,22 +1492,20 @@ img {
   text-align: center;
 }
 
-section[data-type="appendix"] h1 + figure, .abouttheauthor h1 + figure {
+section[data-type="appendix"].abouttheauthor h1 + figure, .abouttheauthor h1 + figure {
   margin-top: -($gridheight * 2);
   margin-bottom: 27pt;
   max-height: 2in;
 }
 
-section[data-type="appendix"] h1 + figure img, .abouttheauthor figure img {
+section[data-type="appendix"].abouttheauthor h1 + figure img, .abouttheauthor figure img {
   max-height: 2in;
 }
 
 img[src*="fullpage"] {
   display: block;
   width: $pagewidth + ($bleedwidth * 2);
-  max-width: none;
   height: $pageheight + ($bleedheight * 2);
-  max-height: none;
   margin-top: -1.65in; }
 
 *[class*="TeaserOpeningTexttotx"], *[class*="TeaserOpeningTextNo-Indenttotx1"] {

--- a/pdfmaker/css/_modules/base.scss
+++ b/pdfmaker/css/_modules/base.scss
@@ -830,6 +830,11 @@ h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: $gridheight * 5;
 }
 
+/* remove top margins from Dedication and Copyright inserted CTNP */
+section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
+section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
+  margin-top: 0; }
+
 section[data-type="chapter"] h1[class*="ChapTitlect"],
 section[data-type="chapter"] h1[class*="ChapTitleALTact"] {
   font-size: $sizechaptitle;

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -793,6 +793,11 @@ section[data-type="chapter"] h1[class*="ChapNumbercn"] + p,
 h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 80pt; }
 
+/* remove top margins from Dedication and Copyright inserted CTNP */
+section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
+section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
+  margin-top: 0; }
+
 section[data-type="chapter"] h1[class*="ChapTitlect"],
 section[data-type="chapter"] h1[class*="ChapTitleALTact"] {
   font-size: 16pt;

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -793,7 +793,8 @@ section[data-type="chapter"] h1[class*="ChapNumbercn"] + p,
 h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 80pt; }
 
-/* remove top margins from Dedication and Copyright inserted CTNP */
+/* remove top margins from Dedication, FM Epigraph, and Copyright inserted CTNP */
+section[data-type="preface"].epigraph h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 0; }
@@ -1080,12 +1081,8 @@ section[data-type="preface"].epigraph,
   page-break-before: right;
   margin-top: 32pt; }
 
-p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
-p[class*="EpigraphSource"] + p[class*="Epigraph-verse"] {
-  margin-top: 32pt; }
-
 section[data-type="dedication"] blockquote[data-type="epigraph"],
-section[data-type="preface"].epigraph {
+section[data-type="preface"].epigraph blockquote[data-type="epigraph"] {
   margin-left: 0;
   margin-right: 0; }
 
@@ -1099,13 +1096,16 @@ section[data-type="preface"] p[class*="Epigraph-non-verse"] {
   text-align: left;
   margin-left: 52pt;
   margin-right: 36pt;
-  text-indent: 12pt; }
+  text-indent: -12pt; }
 
-section[data-type="preface"] p[class*="Epigraph-non-verse"]:first-of-type,
-section[data-type="dedication"] p[class*="Epigraph-non-verse"]:first-of-type {
+section[data-type="dedication"] p[class*="Epigraph-non-verse"],
+section[data-type="preface"].epigraph p[class*="Epigraph-non-verse"] {
+  /*edit 7*/
+  margin-left: 36pt;
   text-indent: 0; }
 
-section[data-type="dedication"] p[class*="EpigraphSource"] {
+section[data-type="dedication"] p[class*="EpigraphSource"],
+section[data-type="preface"] p[class*="EpigraphSource"] {
   font-family: "ArnoPro-SmText", serif, "Noto";
   font-weight: 600;
   font-size: 10pt;
@@ -1148,7 +1148,7 @@ section[data-type="introduction"] > blockquote[data-type="epigraph"] p {
   font-family: "ArnoPro-SmText", "Noto";
   font-size: 10pt;
   line-height: 16pt;
-  text-align: left; }
+  /* text-align: left;  <-- messing with FM epigraph source alignment*/ }
 
 p.ChapEpigraph-versecepiv,
 p.PartEpigraph-versepepiv,

--- a/pdfmaker/css/core_tor.css
+++ b/pdfmaker/css/core_tor.css
@@ -771,6 +771,7 @@ section[data-type="titlepage"] + section[data-type="chapter"],
 section[data-type="halftitlepage"] + section[data-type="chapter"],
 section[data-type="copyright-page"] + section[data-type="chapter"],
 section[data-type="dedication"] + section[data-type="chapter"],
+section[data-type="acknowledgments"] + section[data-type="chapter"],
 nav[data-type="toc"] + section[data-type="chapter"],
 div[data-type="part"] + section[data-type="chapter"] {
   page-break-before: right; }
@@ -1071,7 +1072,7 @@ section[data-type="dedication"] p:first-child {
 section[data-type="dedication"] blockquote[data-type="epigraph"],
 section[data-type="preface"].epigraph,
 .Dedicationded + p[class*="Epigraph"] {
-  page-break-before: always;
+  page-break-before: right;
   margin-top: 32pt; }
 
 p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
@@ -1446,20 +1447,18 @@ img {
   prince-image-resolution: auto, 300dpi;
   text-align: center; }
 
-section[data-type="appendix"] h1 + figure, .abouttheauthor h1 + figure {
+section[data-type="appendix"].abouttheauthor h1 + figure, .abouttheauthor h1 + figure {
   margin-top: -32pt;
   margin-bottom: 27pt;
   max-height: 2in; }
 
-section[data-type="appendix"] h1 + figure img, .abouttheauthor figure img {
+section[data-type="appendix"].abouttheauthor h1 + figure img, .abouttheauthor figure img {
   max-height: 2in; }
 
 img[src*="fullpage"] {
   display: block;
   width: 5.25in;
-  max-width: none;
   height: 8.25in;
-  max-height: none;
   margin-top: -1.65in; }
 
 *[class*="TeaserOpeningTexttotx"], *[class*="TeaserOpeningTextNo-Indenttotx1"] {

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -791,7 +791,8 @@ section[data-type="chapter"] h1[class*="ChapNumbercn"] + p,
 h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 77.5pt; }
 
-/* remove top margins from Dedication and Copyright inserted CTNP */
+/* remove top margins from Dedication, FM Epigraph, and Copyright inserted CTNP */
+section[data-type="preface"].epigraph h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 0; }
@@ -1078,12 +1079,8 @@ section[data-type="preface"].epigraph,
   page-break-before: right;
   margin-top: 31pt; }
 
-p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
-p[class*="EpigraphSource"] + p[class*="Epigraph-verse"] {
-  margin-top: 31pt; }
-
 section[data-type="dedication"] blockquote[data-type="epigraph"],
-section[data-type="preface"].epigraph {
+section[data-type="preface"].epigraph blockquote[data-type="epigraph"] {
   margin-left: 0;
   margin-right: 0; }
 
@@ -1097,13 +1094,16 @@ section[data-type="preface"] p[class*="Epigraph-non-verse"] {
   text-align: left;
   margin-left: 50.375pt;
   margin-right: 35.25pt;
-  text-indent: 12pt; }
+  text-indent: -12pt; }
 
-section[data-type="preface"] p[class*="Epigraph-non-verse"]:first-of-type,
-section[data-type="dedication"] p[class*="Epigraph-non-verse"]:first-of-type {
+section[data-type="dedication"] p[class*="Epigraph-non-verse"],
+section[data-type="preface"].epigraph p[class*="Epigraph-non-verse"] {
+  /*edit 7*/
+  margin-left: 36pt;
   text-indent: 0; }
 
-section[data-type="dedication"] p[class*="EpigraphSource"] {
+section[data-type="dedication"] p[class*="EpigraphSource"],
+section[data-type="preface"] p[class*="EpigraphSource"] {
   font-family: "ArnoPro-SmText", serif, "Noto";
   font-weight: 600;
   font-size: 10pt;
@@ -1146,7 +1146,7 @@ section[data-type="introduction"] > blockquote[data-type="epigraph"] p {
   font-family: "ArnoPro-SmText", "Noto";
   font-size: 10pt;
   line-height: 15.5pt;
-  text-align: left; }
+  /* text-align: left;  <-- messing with FM epigraph source alignment*/ }
 
 p.ChapEpigraph-versecepiv,
 p.PartEpigraph-versepepiv,

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -791,6 +791,11 @@ section[data-type="chapter"] h1[class*="ChapNumbercn"] + p,
 h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 77.5pt; }
 
+/* remove top margins from Dedication and Copyright inserted CTNP */
+section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
+section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
+  margin-top: 0; }
+
 section[data-type="chapter"] h1[class*="ChapTitlect"],
 section[data-type="chapter"] h1[class*="ChapTitleALTact"] {
   font-size: 16pt;

--- a/pdfmaker/css/torDOTcom/novel.css
+++ b/pdfmaker/css/torDOTcom/novel.css
@@ -769,6 +769,7 @@ section[data-type="titlepage"] + section[data-type="chapter"],
 section[data-type="halftitlepage"] + section[data-type="chapter"],
 section[data-type="copyright-page"] + section[data-type="chapter"],
 section[data-type="dedication"] + section[data-type="chapter"],
+section[data-type="acknowledgments"] + section[data-type="chapter"],
 nav[data-type="toc"] + section[data-type="chapter"],
 div[data-type="part"] + section[data-type="chapter"] {
   page-break-before: right; }
@@ -1069,7 +1070,7 @@ section[data-type="dedication"] p:first-child {
 section[data-type="dedication"] blockquote[data-type="epigraph"],
 section[data-type="preface"].epigraph,
 .Dedicationded + p[class*="Epigraph"] {
-  page-break-before: always;
+  page-break-before: right;
   margin-top: 31pt; }
 
 p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
@@ -1444,20 +1445,18 @@ img {
   prince-image-resolution: auto, 300dpi;
   text-align: center; }
 
-section[data-type="appendix"] h1 + figure, .abouttheauthor h1 + figure {
+section[data-type="appendix"].abouttheauthor h1 + figure, .abouttheauthor h1 + figure {
   margin-top: -31pt;
   margin-bottom: 27pt;
   max-height: 2in; }
 
-section[data-type="appendix"] h1 + figure img, .abouttheauthor figure img {
+section[data-type="appendix"].abouttheauthor h1 + figure img, .abouttheauthor figure img {
   max-height: 2in; }
 
 img[src*="fullpage"] {
   display: block;
   width: 5.25in;
-  max-width: none;
   height: 8.25in;
-  max-height: none;
   margin-top: -1.65in; }
 
 *[class*="TeaserOpeningTexttotx"], *[class*="TeaserOpeningTextNo-Indenttotx1"] {
@@ -1558,7 +1557,7 @@ p.PageBreakpb + div.runfoot + div.runheadright + div.runheadleft + * {
 /* glossary definition */
 .Definitiondef {
   font-size: 10.5pt;
-  line-height: 13.8510638298pt;
+  line-height: 13.85106pt;
   text-indent: -24pt;
   margin: 0;
   margin-left: 24pt;

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -793,6 +793,11 @@ section[data-type="chapter"] h1[class*="ChapNumbercn"] + p,
 h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 80pt; }
 
+/* remove top margins from Dedication and Copyright inserted CTNP */
+section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
+section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
+  margin-top: 0; }
+
 section[data-type="chapter"] h1[class*="ChapTitlect"],
 section[data-type="chapter"] h1[class*="ChapTitleALTact"] {
   font-size: 16pt;

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -793,7 +793,8 @@ section[data-type="chapter"] h1[class*="ChapNumbercn"] + p,
 h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 80pt; }
 
-/* remove top margins from Dedication and Copyright inserted CTNP */
+/* remove top margins from Dedication, FM Epigraph, and Copyright inserted CTNP */
+section[data-type="preface"].epigraph h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="copyright-page"] h1[class*="ChapTitleNonprintingctnp"] + *,
 section[data-type="dedication"] h1[class*="ChapTitleNonprintingctnp"] + * {
   margin-top: 0; }
@@ -1080,12 +1081,8 @@ section[data-type="preface"].epigraph,
   page-break-before: right;
   margin-top: 32pt; }
 
-p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
-p[class*="EpigraphSource"] + p[class*="Epigraph-verse"] {
-  margin-top: 32pt; }
-
 section[data-type="dedication"] blockquote[data-type="epigraph"],
-section[data-type="preface"].epigraph {
+section[data-type="preface"].epigraph blockquote[data-type="epigraph"] {
   margin-left: 0;
   margin-right: 0; }
 
@@ -1099,13 +1096,16 @@ section[data-type="preface"] p[class*="Epigraph-non-verse"] {
   text-align: left;
   margin-left: 52pt;
   margin-right: 36pt;
-  text-indent: 12pt; }
+  text-indent: -12pt; }
 
-section[data-type="preface"] p[class*="Epigraph-non-verse"]:first-of-type,
-section[data-type="dedication"] p[class*="Epigraph-non-verse"]:first-of-type {
+section[data-type="dedication"] p[class*="Epigraph-non-verse"],
+section[data-type="preface"].epigraph p[class*="Epigraph-non-verse"] {
+  /*edit 7*/
+  margin-left: 36pt;
   text-indent: 0; }
 
-section[data-type="dedication"] p[class*="EpigraphSource"] {
+section[data-type="dedication"] p[class*="EpigraphSource"],
+section[data-type="preface"] p[class*="EpigraphSource"] {
   font-family: "ArnoPro-SmText", serif, "Noto";
   font-weight: 600;
   font-size: 10pt;
@@ -1148,7 +1148,7 @@ section[data-type="introduction"] > blockquote[data-type="epigraph"] p {
   font-family: "ArnoPro-SmText", "Noto";
   font-size: 10pt;
   line-height: 16pt;
-  text-align: left; }
+  /* text-align: left;  <-- messing with FM epigraph source alignment*/ }
 
 p.ChapEpigraph-versecepiv,
 p.PartEpigraph-versepepiv,

--- a/pdfmaker/css/torDOTcom/pdf.css
+++ b/pdfmaker/css/torDOTcom/pdf.css
@@ -771,6 +771,7 @@ section[data-type="titlepage"] + section[data-type="chapter"],
 section[data-type="halftitlepage"] + section[data-type="chapter"],
 section[data-type="copyright-page"] + section[data-type="chapter"],
 section[data-type="dedication"] + section[data-type="chapter"],
+section[data-type="acknowledgments"] + section[data-type="chapter"],
 nav[data-type="toc"] + section[data-type="chapter"],
 div[data-type="part"] + section[data-type="chapter"] {
   page-break-before: right; }
@@ -1071,7 +1072,7 @@ section[data-type="dedication"] p:first-child {
 section[data-type="dedication"] blockquote[data-type="epigraph"],
 section[data-type="preface"].epigraph,
 .Dedicationded + p[class*="Epigraph"] {
-  page-break-before: always;
+  page-break-before: right;
   margin-top: 32pt; }
 
 p[class*="EpigraphSource"] + p[class*="Epigraph-non-verse"],
@@ -1446,20 +1447,18 @@ img {
   prince-image-resolution: auto, 300dpi;
   text-align: center; }
 
-section[data-type="appendix"] h1 + figure, .abouttheauthor h1 + figure {
+section[data-type="appendix"].abouttheauthor h1 + figure, .abouttheauthor h1 + figure {
   margin-top: -32pt;
   margin-bottom: 27pt;
   max-height: 2in; }
 
-section[data-type="appendix"] h1 + figure img, .abouttheauthor figure img {
+section[data-type="appendix"].abouttheauthor h1 + figure img, .abouttheauthor figure img {
   max-height: 2in; }
 
 img[src*="fullpage"] {
   display: block;
   width: 5.25in;
-  max-width: none;
   height: 8.25in;
-  max-height: none;
   margin-top: -1.65in; }
 
 *[class*="TeaserOpeningTexttotx"], *[class*="TeaserOpeningTextNo-Indenttotx1"] {


### PR DESCRIPTION
@lsquill, please review?

These are my edits to Erica's css branch, to fix/revise handling of:
• epigraph leading page missing.
• squashed back-ad
• rm-ing unwanted top-margins from sections with auto-inserted CTNP's (FM epigraph, Dedication, Copyright)
• weird epigraph margins and alignment.

Some of these just needed more fixing, others were new or introduced issues through other patches since the last round of tests.